### PR TITLE
fix decode error for non valid ascii characters

### DIFF
--- a/cloudvision/Connector/codec/decoder.py
+++ b/cloudvision/Connector/codec/decoder.py
@@ -42,7 +42,7 @@ class Decoder(object):
 
     def __postProcess(self, b):
         if isinstance(b, bytes):
-            return b.decode("ascii")
+            return b.decode("ascii", "ignore")
         elif isinstance(b, list):
             return self.decode_array(b)
         elif isinstance(b, (dict, FrozenDict)):


### PR DESCRIPTION
In reference to issue #5 

This is to resolve an issue where the ascii decode cannot successfully decode all of the characters in the BGPOpensent messages. Adding the ignore statement will allow the code to progress even when it comes across a non-valid ascii character.