### PR TITLE
examples: fix get_connectivity_monitor example

### DIFF
--- a/examples/resources/connectivitymonitor/get_connectivity_monitor.py
+++ b/examples/resources/connectivitymonitor/get_connectivity_monitor.py
@@ -122,25 +122,6 @@ def getConnMonCfg(channel, device=None):
     return result
 
 
-def get(client, dataset, pathElts):
-    """Returns a query on a path element"""
-    result = {}
-    query = [create_query([(pathElts, [])], dataset)]
-
-    for batch in client.get(query):
-        for notif in batch["notifications"]:
-            if debug:
-                print(notif["updates"])
-            result.update(notif["updates"])
-    return result
-
-
-def getSwitchInfo(client, device):
-    pathElts = ["DatasetInfo", "Devices"]
-    dataset = "analytics"
-    return get(client, dataset, pathElts)
-
-
 def report(serialNumberToHostnameDict, data, configData, device):
     for k, v in data.items():
         hostname = serialNumberToHostnameDict[k[0]]

--- a/examples/resources/connectivitymonitor/get_connectivity_monitor.py
+++ b/examples/resources/connectivitymonitor/get_connectivity_monitor.py
@@ -32,10 +32,11 @@ def getSerialNumberToHostnameDict(channel):
     stub = services.DeviceServiceStub(channel)
     # create a stream request
     get_all_req = services.DeviceStreamRequest()
-     # make the GetAll request and loop over the streamed responses
+    # make the GetAll request and loop over the streamed responses
     for resp in stub.GetAll(get_all_req, timeout=RPC_TIMEOUT):
         device_dict[resp.value.key.device_id.value] = resp.value.hostname.value
     return device_dict
+
 
 def getConnMon(channel, device=None):
     connMonGetAll = ProbeStatsStreamRequest()
@@ -56,12 +57,13 @@ def getConnMon(channel, device=None):
     result = {}
 
     for resp in connStub.GetAll(connMonGetAll):
+        device_id = resp.value.key.device_id.value
         vrfName = resp.value.key.vrf.value
         hostName = resp.value.key.host.value
         intf = resp.value.key.source_intf.value
 
         connMonKeyVals = (
-            connMonKey.device_id.value,
+            device_id,
             hostName,
             vrfName,
             intf
@@ -100,11 +102,12 @@ def getConnMonCfg(channel, device=None):
     result = {}
 
     for resp in configStub.GetAll(configGetAll):
+        device_id = resp.value.key.device_id.value
         vrfName = resp.value.key.vrf.value
         hostName = resp.value.key.host.value
 
         probeKeyVals = (
-            probeKey.device_id.value,
+            device_id,
             hostName,
             vrfName,
         )
@@ -122,9 +125,11 @@ def getConnMonCfg(channel, device=None):
     return result
 
 
-def report(serialNumberToHostnameDict, data, configData, device):
+def report(serialNumberToHostnameDict, data, configData):
+    report_list = []
     for k, v in data.items():
-        hostname = serialNumberToHostnameDict[k[0]]
+        serial_number = k[0]
+        hostname = serialNumberToHostnameDict[serial_number]
         host = k[1]
         vrf = k[2]
         intf = k[3]
@@ -132,14 +137,31 @@ def report(serialNumberToHostnameDict, data, configData, device):
         jitter = v["jitter"]
         latency = v["latency"]
         pktloss = v["packet_loss"]
-        if "ip_addr" in configData[(device, host, vrf)]:
-            ipaddr = configData[(device, host, vrf)]["ip_addr"]
+        if "ip_addr" in configData[(serial_number, host, vrf)]:
+            ipaddr = configData[(serial_number, host, vrf)]["ip_addr"]
         else:
             ipaddr = ""
-        hdr_part1 = f"{hostname + ' (' + vrf + '/' + intf + ') to ' + host:<50}"
-        hdr_part2 = f"{ipaddr:<30}{str(httpResp) + 'ms':<30}{str(jitter) + 'ms':<30}"
-        hdr_part3 = f"{str(latency) + 'ms':<30}{str(pktloss)  + '%':<30}"
-        print(hdr_part1 + hdr_part2 + hdr_part3)
+        if "description" in configData[(serial_number, host, vrf)]:
+            description = configData[(serial_number, host, vrf)]["description"]
+        else:
+            description = ""
+
+        report_list.append({
+            "hostname": hostname,
+            "serial_number": serial_number,
+            "vrf": vrf,
+            "interface": intf,
+            "host": host,
+            "ip_addr": ipaddr,
+            "description": description,
+            "http_response": httpResp,
+            "jitter": jitter,
+            "latency": latency,
+            "packet_loss": pktloss
+        })
+
+    print(report_list)
+    return report_list
 
 
 def main(apiserverAddr, token=None, certs=None, key=None, ca=None):
@@ -157,7 +179,7 @@ def main(apiserverAddr, token=None, certs=None, key=None, ca=None):
         data = getConnMon(channel, args.device)
         configData = getConnMonCfg(channel, args.device)
         serialNumberToHostnameDict = getSerialNumberToHostnameDict(channel)
-        report(serialNumberToHostnameDict, data, configData, args.device)
+        report(serialNumberToHostnameDict, data, configData)
 
 
 if __name__ == "__main__":

--- a/examples/resources/connectivitymonitor/get_connectivity_monitor.py
+++ b/examples/resources/connectivitymonitor/get_connectivity_monitor.py
@@ -126,7 +126,7 @@ def getConnMonCfg(channel, device=None):
 
 
 def report(serialNumberToHostnameDict, data, configData):
-    report_list = []
+    connectivity_reports = []
     for k, v in data.items():
         serial_number = k[0]
         hostname = serialNumberToHostnameDict[serial_number]
@@ -146,7 +146,7 @@ def report(serialNumberToHostnameDict, data, configData):
         else:
             description = ""
 
-        report_list.append({
+        connectivity_reports.append({
             "hostname": hostname,
             "serial_number": serial_number,
             "vrf": vrf,
@@ -160,8 +160,8 @@ def report(serialNumberToHostnameDict, data, configData):
             "packet_loss": pktloss
         })
 
-    print(report_list)
-    return report_list
+    print(connectivity_reports)
+    return connectivity_reports
 
 
 def main(apiserverAddr, token=None, certs=None, key=None, ca=None):


### PR DESCRIPTION
When using the example in examples/resources/connectivitymonitor, I got the following error: 

```
$ python3 get_connectivity_monitor.py --apiserver <MY-CVP-IP>:443 --token token.txt --cert cvp.crt --device <DEVICE-SN>
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
F0000 00:00:1730382229.854067 1242722 ssl_credentials.cc:149] Check failed: pem_key_cert_pair->private_key != nullptr ((null) vs. (null)) 
*** Check failure stack trace: ***
Aborted (core dumped)
```
This error comes from the GRPCClient, and we are using that class only to get the mapping between S/N to hostname. 

In this PR, I replaced the GRPCClient with inventory resources to get the inventory data, which makes more sense from my point of view as we are already using the resources API to get connectivity monitor info. 