### PR TITLE
CWE-1395 CWE-125: Allow the latest cryptography library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aristaproto==0.1.5
-cryptography==48.0.1
+cryptography>=49.0.0
 grpcio>=1.53.0
 msgpack>=1.0.3
 protobuf>=5.28.3,<6.0dev


### PR DESCRIPTION
pyca/cryptography's wheels include a statically linked copy of OpenSSL. The versions of OpenSSL included in wheels prior to cryptography 48.01 are vulnerable to a security issue.
More details about the vulnerability itself can be found at https://openssl-library.org/news/secadv/20260609.txt.

I'm unsure why there's a pin to the specific 48.0.1 version, but that effectively prevents us from upgrading to the latest cryptography release that resolves the security issues.

I'd also relax the conditions and permit the installation of other future versions.

If the maintainers agree with these changes, please release a new minor version on PyPI at your earliest convenience.